### PR TITLE
fix implicit fall-through gcc warnings

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -522,6 +522,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
     case FFI_REGISTER:
       dest = ffi_closure_REGISTER;
       op = 0x68;  /* pushl imm */
+      // fall through
     default:
       return FFI_BAD_ABI;
     }

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -199,6 +199,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 	else
 	  FFI_ASSERT (0);
       }
+      break;
     case FFI_TYPE_FLOAT:
       if (!(byte_offset % 8))
 	classes[0] = X86_64_SSESF_CLASS;


### PR DESCRIPTION
This patch addresses implicit fallthrough warnings on the
newer gcc compiler. Proper comment to silence the warning or appropriate comments
have been added in the case statements.

Signed-off-by: Ani Sinha <ani@anisinha.ca>